### PR TITLE
Updated auditory_toolbox_torch.py and auditory_toolbox_torch_test.py

### DIFF
--- a/auditory_toolbox_torch_test.py
+++ b/auditory_toolbox_torch_test.py
@@ -45,6 +45,7 @@ class AuditoryToolboxTests(absltest.TestCase):
     self.assertEqual(b2.numpy().shape, (num_chan, 1))
     self.assertEqual(gain.numpy().shape, (num_chan, 1))
 
+
   def test_erb_filterbank_peaks(self):
     """Test peaks."""
 


### PR DESCRIPTION
- Some typing cleanups
- Shifted FM points output back by one sample as in the other python implementations. This diverges from Matlab implementation. 
- Fixed a minor bug related to definition of filter coefficients

To do:
- Coordinate / align definition of fft_size in correlogram function. 
